### PR TITLE
Allow for other upickle "API"s

### DIFF
--- a/ujson/src/main/scala/datum/ujsonlib/implicits/package.scala
+++ b/ujson/src/main/scala/datum/ujsonlib/implicits/package.scala
@@ -1,5 +1,8 @@
 package datum.ujsonlib
-import datum.ujsonlib.properties.PropertyReadWriter
+import datum.patterns.schemas.Schema
 import datum.ujsonlib.schemas.SchemaReadWriter
 
-package object implicits extends SchemaReadWriter with PropertyReadWriter
+package object implicits {
+  import upickle.default._
+  implicit val schemaRW: ReadWriter[Schema] = SchemaReadWriter(upickle.default)
+}

--- a/ujson/src/main/scala/datum/ujsonlib/properties/PropertyReadWriter.scala
+++ b/ujson/src/main/scala/datum/ujsonlib/properties/PropertyReadWriter.scala
@@ -2,7 +2,6 @@ package datum.ujsonlib.properties
 
 import datum.patterns.properties._
 import higherkindness.droste._
-import upickle.default._
 
 import scala.collection.immutable.SortedMap
 
@@ -27,21 +26,19 @@ object PropertyReadWriter {
       builder ++= fields.iterator
       CollectionPropF(builder.result())
   }
-}
 
-trait PropertyReadWriter {
-  import PropertyReadWriter._
-
-  implicit val attrReadWrite: ReadWriter[Property] = upickle.default
-    .readwriter[ujson.Value]
-    .bimap[Property](
-      attr => {
-        val toJsonFn = scheme.cata(algebra)
-        toJsonFn(attr)
-      },
-      js => {
-        val fromJsonFn = scheme.ana(coalgebra)
-        fromJsonFn(js)
-      }
-    )
+  def propertyRW(implicit api: upickle.Api): api.ReadWriter[Property] = {
+    api
+      .readwriter[ujson.Value](api.ReadWriter.join(api.JsValueR, api.JsValueW))
+      .bimap[Property](
+        attr => {
+          val toJsonFn = scheme.cata(algebra)
+          toJsonFn(attr)
+        },
+        js => {
+          val fromJsonFn = scheme.ana(coalgebra)
+          fromJsonFn(js)
+        }
+      )
+  }
 }

--- a/ujson/src/main/scala/datum/ujsonlib/schemas/SchemaReadWriter.scala
+++ b/ujson/src/main/scala/datum/ujsonlib/schemas/SchemaReadWriter.scala
@@ -4,17 +4,19 @@ import datum.patterns.properties._
 import datum.patterns.schemas._
 import datum.ujsonlib.properties.PropertyReadWriter
 import higherkindness.droste.{Algebra, Coalgebra, scheme}
-import upickle.default._
 
 import scala.collection.immutable.SortedMap
 
-trait SchemaReadWriter { self: PropertyReadWriter =>
+class SchemaReadWriter[API <: upickle.Api](implicit val api: API) {
+
+  import api._
+  private implicit val propRW: ReadWriter[Property] = PropertyReadWriter.propertyRW(api)
 
   val algebra: Algebra[SchemaF, ujson.Value] = Algebra {
     case ObjF(fields, properties) =>
       ujson.Obj(
         "fields" -> fields,
-        "properties" -> writeJs(properties)
+        "properties" -> api.writeJs(properties)
       )
 
     case RowF(columns, properties) =>
@@ -28,35 +30,35 @@ trait SchemaReadWriter { self: PropertyReadWriter =>
                 ujson.Obj("schema" -> col.value)
             }
           ),
-        "properties" -> writeJs(properties)
+        "properties" -> api.writeJs(properties)
       )
 
     case ArrayF(element, properties) =>
       ujson.Obj(
         "array" -> element,
-        "properties" -> writeJs(properties)
+        "properties" -> api.writeJs(properties)
       )
 
     case UnionF(alternatives, properties) =>
       ujson.Obj(
         "union" -> alternatives,
-        "properties" -> writeJs(properties)
+        "properties" -> api.writeJs(properties)
       )
 
     case ValueF(tpe, properties) =>
       ujson.Obj(
         "type" -> Type.asString(tpe),
-        "properties" -> writeJs(properties)
+        "properties" -> api.writeJs(properties)
       )
   }
 
   val coalgebra: Coalgebra[SchemaF, ujson.Value] = Coalgebra[SchemaF, ujson.Value] {
     case ujson.Obj(fields) if fields.contains("type") =>
-      val props = read[Map[String, Property]](fields("properties"))
+      val props = api.read[Map[String, Property]](fields("properties"))
       ValueF(Type.fromString(fields("type").str).get, props)
 
     case ujson.Obj(fields) if fields.contains("columns") =>
-      val props = read[Map[String, Property]](fields("properties"))
+      val props = api.read[Map[String, Property]](fields("properties"))
       val elements = fields("columns").arr.view.map { colJs =>
         val header = colJs.obj.get("header").map(_.str)
         Column[ujson.Value](colJs("schema"), header)
@@ -64,31 +66,36 @@ trait SchemaReadWriter { self: PropertyReadWriter =>
       RowF(elements, props)
 
     case ujson.Obj(fields) if fields.contains("array") =>
-      val props = read[Map[String, Property]](fields("properties"))
+      val props = api.read[Map[String, Property]](fields("properties"))
       ArrayF(fields("array"), props)
 
     case ujson.Obj(fields) if fields.contains("fields") =>
-      val props = read[Map[String, Property]](fields("properties"))
+      val props = api.read[Map[String, Property]](fields("properties"))
       ObjF(SortedMap(fields("fields").obj.toSeq: _*), props)
 
     case ujson.Obj(fields) if fields.contains("union") =>
-      val props = read[Map[String, Property]](fields("properties"))
+      val props = api.read[Map[String, Property]](fields("properties"))
       UnionF(SortedMap(fields("union").obj.toSeq: _*), props)
 
     case invalid => throw SchemaReadWriter.InvalidSchemaJson(invalid)
   }
-
-  implicit val scheamReadWrite: ReadWriter[Schema] = upickle.default
-    .readwriter[ujson.Value]
-    .bimap[Schema](schema => {
-      val toJsonFn = scheme.cata(algebra)
-      toJsonFn(schema)
-    }, js => {
-      val fromJsFn = scheme.ana(coalgebra)
-      fromJsFn(js)
-    })
 }
 
 object SchemaReadWriter {
+
+  def apply[API <: upickle.Api](implicit api: API) = {
+    val schemaReadWriter = new SchemaReadWriter[API]
+    val schemaRW: api.ReadWriter[Schema] = api
+      .readwriter[ujson.Value](api.ReadWriter.join(api.JsValueR, api.JsValueW))
+      .bimap[Schema](schema => {
+        val toJsonFn = scheme.cata(schemaReadWriter.algebra)
+        toJsonFn(schema)
+      }, js => {
+        val fromJsFn = scheme.ana(schemaReadWriter.coalgebra)
+        fromJsFn(js)
+      })
+    schemaRW
+  }
+
   case class InvalidSchemaJson(invalid: ujson.Value) extends Exception(s"Could not convert json to schema: $invalid")
 }


### PR DESCRIPTION
Although the default implicit import still uses upickle.default, it is now possible to provide a custom API definition to change the json serialization behavior. 